### PR TITLE
feat: limit memory usage on large cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,3 +265,12 @@ go run github.com/onsi/ginkgo/v2/ginkgo run --focus "Node.js" internal/helpers/
 ### Dockerhub
 
 [source](https://www.docker.com/blog/checking-your-current-docker-pull-rate-limits-and-status)
+
+https://gist.github.com/j33ty/79e8b736141be19687f565ea4c6f4226
+
+https://github.com/kubernetes-sigs/controller-runtime/blob/main/designs/cache_options.md
+https://github.com/kubernetes-sigs/controller-runtime/issues?q=cache
+https://medium.com/@timebertt/kubernetes-controllers-at-scale-clients-caches-conflicts-patches-explained-aa0f7a8b4332
+https://tyk.io/blog/the-role-of-controller-runtime-manager-in-kubernetes-operators/
+https://github.com/external-secrets/external-secrets/issues/721
+https://github.com/operator-framework/operator-sdk/issues/6255

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,12 +27,15 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -122,6 +125,11 @@ func main() {
 	if helpers.GetEnv("FEATURE_DOCKERHUB_RATE_LIMIT_ENABLED", "false") == "true" {
 		go heartBeatDockerhub(setupLog)
 	}
+	var namespaces = strings.Split(helpers.GetEnv("FEATURE_COPY_ON_THE_FLY_NAMESPACES_ALLOWED", "*"), ",")
+	cacheNamespaces := make(map[string]cache.Config)
+	for _, namespace := range namespaces {
+		cacheNamespaces[namespace] = cache.Config{}
+	}
 
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -199,12 +207,24 @@ func main() {
 		}
 
 		mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-			Scheme:                 scheme,
+			Scheme: scheme,
+			Client: client.Options{
+				Cache: &client.CacheOptions{
+					DisableFor: []client.Object{
+						&corev1.Secret{},
+						&corev1.ConfigMap{},
+						&corev1.Pod{},
+					},
+				},
+			},
 			Metrics:                metricsServerOptions,
 			WebhookServer:          webhookServer,
 			HealthProbeBindAddress: probeAddr,
 			LeaderElection:         enableLeaderElection,
 			LeaderElectionID:       "dce26553.skopeo.io",
+			Cache: cache.Options{
+				DefaultNamespaces: cacheNamespaces,
+			},
 			// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 			// when the Manager ends. This requires the binary to immediately end when the
 			// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -241,11 +261,11 @@ func main() {
 		}
 
 		// Activate copy on fly feature. Disabled by default
-		if helpers.GetEnv("FEATURE_COPY_ON_THE_FLY_ENABLED", "false") == "true" {
+		if helpers.GetEnv("FEATURE_COPY_ON_THE_FLY_ENABLED", "true") == "true" {
 			if err = (&corecontroller.PodReconciler{
 				Client:                mgr.GetClient(),
 				Scheme:                mgr.GetScheme(),
-				OnFlyNamespaceAllowed: strings.Split(helpers.GetEnv("FEATURE_COPY_ON_THE_FLY_NAMESPACES_ALLOWED", "*"), ","),
+				OnFlyNamespaceAllowed: namespaces,
 			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "Pod")
 				os.Exit(1)

--- a/internal/controller/buildah.io/imagebuilder_controller.go
+++ b/internal/controller/buildah.io/imagebuilder_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -124,7 +125,7 @@ func (r *ImageBuilderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *ImageBuilderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&buildahiov1alpha1.ImageBuilder{}).
-		Owns(&batchv1.Job{}).
+		Owns(&batchv1.Job{}, builder.OnlyMetadata).
 		Complete(r)
 }
 

--- a/internal/controller/core/pod_controller.go
+++ b/internal/controller/core/pod_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var notFoundImageCache []string
@@ -62,7 +63,6 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err := r.Get(ctx, req.NamespacedName, &event); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-
 	// Event on the pod
 	if event.Reason != "Failed" {
 		return ctrl.Result{}, nil
@@ -154,7 +154,15 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&corev1.Pod{}).
 		Watches(
 			&corev1.Event{},
-			&handler.EnqueueRequestForObject{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
+				// if !helpers.Contains(allowedNamespaces, object.GetNamespace()) {
+				//	return []reconcile.Request{}
+				// }
+
+				return []reconcile.Request{{
+					NamespacedName: client.ObjectKeyFromObject(object),
+				}}
+			}),
 		).
 		Complete(r)
 }

--- a/internal/controller/skopeo.io/create_skopeo_job.go
+++ b/internal/controller/skopeo.io/create_skopeo_job.go
@@ -145,6 +145,25 @@ func GenerateSkopeoJob(
 					Labels:      image.Labels,
 				},
 				Spec: corev1.PodSpec{
+					// Affinity: &corev1.Affinity{
+					// 	NodeAffinity: &corev1.NodeAffinity{
+					// 		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					// 			NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					// 				MatchExpressions: []corev1.NodeSelectorRequirement{{
+					// 					Key:      "infra-tools",
+					// 					Operator: "In",
+					// 					Values:   []string{"true"},
+					// 				}},
+					// 			}},
+					// 		},
+					// 	},
+					// },
+					// Tolerations: []corev1.Toleration{{
+					// 	 Effect:   "NoSchedule",
+					// 	 Key:      "role",
+					// 	 Operator: "Equal",
+					// 	 Value:    "infra-tools",
+					// }},
 					RestartPolicy: "Never",
 					Containers: []corev1.Container{
 						{

--- a/internal/helpers/memory.go
+++ b/internal/helpers/memory.go
@@ -1,0 +1,19 @@
+package helpers
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func bToMb(b uint64) uint64 {
+	return b / 1024 / 1024
+}
+
+func displayMemoryUsage() {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
+	fmt.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
+	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
+	fmt.Printf("\tNumGC = %v\n", m.NumGC)
+}


### PR DESCRIPTION
On a large cluster, the memory print is around 1GB (it's too much).
For the on-fly copy feature, we listen every pod event.
This PR tries to limit listened namespaces.